### PR TITLE
feat(ci): add Node.js v16, remove Node.js v10

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10, 12, 14]
+        node-version: [12, 14, 16]
         os: [ubuntu-latest]
     steps:
     - name: Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "10 || 12 || >=14"
+    "node": "12 || 14 || >=16"
   },
   "scripts": {
     "lint": "eslint *.js test/*.js",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is no longer supported. Node.js v12 is now
the minimum supported version of Node.js.